### PR TITLE
Introduce universal helper script in config map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ all:
 	mkdir -p deployments/$(monkey); \
 	cp -r monkeys/$(monkey)/deployments/* deployments/$(monkey)/; \
 	kubectl create --dry-run configmap chaos-test-$(monkey)-script \
-		--from-file=monkeys/$(monkey)/run.sh \
+		--from-file=monkeys/$(monkey)/run.sh --from-file=lib/helpers.bash \
 		-o yaml > deployments/$(monkey)/chaos-test-$(monkey)-script.yaml; \
 	$(foreach valueFile,$(foreach path,$(wildcard monkeys/$(monkey)/values-*.yaml),$(path:monkeys/$(monkey)/%=%)),\
-	       helm template monkeys/$(monkey) --set basename=$(monkey) -f monkeys/$(monkey)/$(valueFile) > deployments/$(monkey)-$(valueFile);))
+	       helm template monkeys/$(monkey) --set basename=$(monkey) -f monkeys/$(monkey)/$(valueFile) > deployments/$(monkey)/$(valueFile);))
 
 deploy:
 	$(foreach monkey,$(MONKEYS),kubectl -n chaos-testing apply -f deployments/$(monkey);)

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl bash ca-certificates iproute2 \
+    && apt-get install -y --no-install-recommends curl bash ca-certificates iproute2 tcpdump \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -LO http://releases.cilium.io/v1.1.1/cilium-x86_64 && \
     chmod +x cilium-x86_64 && \

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+export ENDPOINT_IP=$(ip -4 a list dev eth0 | grep inet |  grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | head -1)
+export ENDPOINT_ID=$(cilium endpoint list | grep $ENDPOINT_IP | cut -d' ' -f 1)
+
+
+function init_monkey() {
+	[ -z "$SLACK_HOOK" ] && {
+		echo "SLACK_HOOK not provided"
+		exit 1
+	}
+}
+
+function endpoint_debug_enable() {
+	cilium endpoint config $ENDPOINT_ID debug=true
+}
+
+function endpoint_debug_disable() {
+	cilium endpoint config $ENDPOINT_ID debug=false
+}
+
+MONITOR_TMP="$(mktemp)"
+MONITOR_PID="0"
+
+function start_monitor() {
+	[ "$MONITOR_PID" -ne "0" ] && {
+		echo "Monitor is already running"
+		return
+	}
+
+	cilium monitor -v > $MONITOR_TMP&
+	MONITOR_PID=$!
+}
+
+function stop_monitor() {
+	[ "$MONITOR_PID" -ne "0" ] && {
+		kill $MONITOR_PID || {
+			kill -9 $MONITOR_PID 2> /dev/null || true
+		}
+
+		MONITOR_PID="0"
+	}
+}
+
+function cleanup_monitor() {
+	rm $MONITOR_TMP 2> /dev/null || true
+}
+
+TCPDUMP_TMP="$(mktemp)"
+TCPDUMP_PID="0"
+
+function start_tcpdump() {
+	[ "$TCPDUMP_PID" -ne "0" ] && {
+		echo "tcpdump is already running"
+		return
+	}
+
+	tcpdump -n -i eth0 -s 0 -v > $TCPDUMP_TMP 2>&1 &
+	TCPDUMP_PID=$!
+
+	sleep 1
+}
+
+function stop_tcpdump() {
+	[ "$TCPDUMP_PID" -ne "0" ] && {
+		kill $TCPDUMP_PID || {
+			kill -9 $TCPDUMP_PID 2> /dev/null || true
+		}
+
+		TCPDUMP_PID="0"
+	}
+}
+
+function cleanup_tcpdump() {
+	rm $TCPDUMP_TMP 2> /dev/null || true
+}
+
+function notify_slack() {
+	MSG="{\"text\": \"$*\"}"
+	curl -XPOST -d "$MSG" $SLACK_HOOK
+}
+
+function test_fail() {
+	echo "----------------------------------------------------------------------------"
+	echo "Test failed"
+	echo ""
+	echo "EndpointID: $ENDPOINT_ID"
+	echo "EndpointIP: $ENDPOINT_IP"
+	echo "----------------------------------------------------------------------------"
+
+	echo "----------------------------------------------------------------------------"
+	echo "Endpoint List"
+	echo "----------------------------------------------------------------------------"
+	cilium endpoint list
+
+	echo "----------------------------------------------------------------------------"
+	echo "Endpoint"
+	echo "----------------------------------------------------------------------------"
+	cilium endpoint get $ENDPOINT_ID -o json
+
+	echo "----------------------------------------------------------------------------"
+	echo "Policy repository"
+	echo "----------------------------------------------------------------------------"
+	cilium policy get
+
+	echo "----------------------------------------------------------------------------"
+	echo "Endpoint policy"
+	echo "----------------------------------------------------------------------------"
+	cilium bpf policy get $ENDPOINT_ID
+
+	echo "----------------------------------------------------------------------------"
+	echo "Service List"
+	echo "----------------------------------------------------------------------------"
+	cilium service list
+	cilium bpf lb list
+
+	[ -s "$MONITOR_TMP" ] && {
+		echo "----------------------------------------------------------------------------"
+		echo "Monitor Log"
+		echo "----------------------------------------------------------------------------"
+		cat $MONITOR_TMP
+	}
+
+	[ -s "$TCPDUMP_TMP" ] && {
+		echo "----------------------------------------------------------------------------"
+		echo "tcpdump"
+		echo "----------------------------------------------------------------------------"
+		cat $TCPDUMP_TMP
+	}
+}
+
+function cleanup() {
+	stop_tcpdump
+	cleanup_tcpdump
+	stop_monitor
+	cleanup_monitor
+}
+
+trap cleanup EXIT

--- a/monkeys/et-call-home/run.sh
+++ b/monkeys/et-call-home/run.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-[ -z "$SLACK_HOOK" ] && {
-	echo "SLACK_HOOK not provided"
-	exit 1
-}
+. $(dirname ${BASH_SOURCE})/helpers.bash
+
+init_monkey
 
 [ -z "$URL" ] && {
 	echo "URL not provided"
@@ -14,37 +13,27 @@
 	SLEEP="10"
 }
 
-ENDPOINT_IP=$(ip -4 a list dev eth0 | grep inet |  grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | head -1)
-ENDPOINT_ID=$(cilium endpoint list | grep $ENDPOINT_IP | cut -d' ' -f 1)
-cilium endpoint config $ENDPOINT_ID debug=true
+endpoint_debug_enable
 
 while :
 do
-	TMP=$(mktemp)
-	cilium monitor -v > $TMP&
-	MONITOR_PID=$!
+	start_monitor
+	start_tcpdump
 
 	echo -n "Trying to call home ($URL): "
 
-	time curl -s $CURL_OPTIONS 10 $URL > /dev/null
+	time curl -4 -s $CURL_OPTIONS 10 $URL > /dev/null
 	CODE=$?
 	echo "$CODE"
 
-	kill $MONITOR_PID || true
-	sleep 2
-	kill -9 $MONITOR_PID 2> /dev/null || true
+	stop_monitor
+	stop_tcpdump
 
 	[ "$CODE" -ne "0" ] && {
-		MSG="{\"text\": \":fire: *E.T. ($HOSTNAME) cannot call home!* (exit code $CODE) :face_palm:\"}"
-		curl -XPOST -d "$MSG" $SLACK_HOOK
-
-		echo 'Monitor log:'
-		cat $TMP
-		rm $TMP
+		notify_slack ":fire: *E.T. ($HOSTNAME) cannot call home!* (exit code $CODE) :face_palm:"
+		test_failed
 		exit 1
 	}
-
-	rm $TMP
 
 	sleep $SLEEP
 done

--- a/templates/monkey-deployment.yaml
+++ b/templates/monkey-deployment.yaml
@@ -12,6 +12,7 @@ spec:
       containers:
       - name: {{ .Values.basename }}
         image: docker.io/cilium/chaos-test-base:1.0
+        imagePullPolicy: Always
         command: [ "/test/run.sh" ]
         env:
           - name: "SLACK_HOOK"
@@ -28,6 +29,8 @@ spec:
           mountPath: /test
         - name: bpf-maps
           mountPath: /sys/fs/bpf
+        - name: cilium-run
+          mountPath: /var/run/cilium
         securityContext:
           capabilities:
             add:
@@ -41,3 +44,6 @@ spec:
       - name: bpf-maps
         hostPath:
           path: /sys/fs/bpf
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium


### PR DESCRIPTION
Allows to consistently:
- enable debug mode on the test endpoint
- collect the cilium monitor and tcpdump output and dump it on test failure
- collect common output on test failure

Signed-off-by: Thomas Graf <thomas@cilium.io>