### PR TITLE
Add timestamps to monitor output

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl bash ca-certificates iproute2 tcpdump netcat \
+    && apt-get install -y --no-install-recommends curl bash ca-certificates iproute2 tcpdump netcat moreutils \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -LO http://releases.cilium.io/v1.2.0/cilium-x86_64 && \
     chmod +x cilium-x86_64 && \

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -28,7 +28,7 @@ function start_monitor() {
 		return
 	}
 
-	cilium monitor -v > $MONITOR_TMP&
+	cilium monitor -v | ts > $MONITOR_TMP&
 	MONITOR_PID=$!
 }
 


### PR DESCRIPTION
Update the docker image to install `moreutils` for the `ts` utility, and use
this from the helper scripts so we can get timestamps when the monitor
receives an event. This should make it easier to correlate logs and tcpdump
output with the monitor output.