### PR TITLE
Include all shell and jq scripts as data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,13 @@ all:
 	$(foreach monkey,$(MONKEYS),\
 	mkdir -p deployments/$(monkey); \
 	kubectl create --dry-run configmap chaos-test-$(monkey)-script \
-		--from-file=monkeys/$(monkey)/run.sh --from-file=lib/helpers.bash \
+		--from-file=lib/helpers.bash \
+		$(foreach script,$(wildcard monkeys/$(monkey)/*.sh),\
+			"--from-file=$(script)"\
+		) \
+		$(foreach script,$(wildcard monkeys/$(monkey)/*.jq),\
+			"--from-file=$(script)"\
+		) \
 		-o yaml > deployments/$(monkey)/chaos-test-$(monkey)-script.yaml; \
 	$(foreach valueFile,$(foreach path,$(wildcard monkeys/$(monkey)/values-*.yaml),$(path:monkeys/$(monkey)/%=%)),\
 	       helm template monkeys/$(monkey) --set basename=$(monkey) -f monkeys/$(monkey)/$(valueFile) > deployments/$(monkey)/$(valueFile);))


### PR DESCRIPTION
Make all files that are directly under a monkey directory with the suffix `.jq` or `.sh` available under the `test/` directory inside a pod.