### PR TITLE
Add create-monkey script to initialize new monkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ failures:
 Deploy the test monkeys:
 
 	make deploy
+
+## How to create a new monkey
+
+A new monkey can be initialized from templates using the following command:
+
+	./create-monkey
+
+If run without arguments, it will print usage instructions for initializing
+the configuration files for your new monkey. When a monkey name is specified,
+it will set up "monkey/{{MONKEY_NAME}}" based on templated files.

--- a/create-monkey
+++ b/create-monkey
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -e
+
+ECHO=""
+BARREL=0
+POLICY=0
+
+function usage() {
+	(
+		echo "Usage: $0 [OPTION ...] <monkey-name>"
+		echo
+		echo "Create a new monkey from templates."
+		echo
+		echo "A monkey may be created as a deployment of cloned monkeys" \
+		     "(the default), or as a statefulset of two monkeys which" \
+		     "operate together (--barrel)."
+		echo
+		echo "Options:"
+		echo "  -b,--barrel	Create a barrel of monkeys (2)"
+		echo "  -p,--policy	Set up default policy for slack hook"
+	)
+}
+
+# $1: Monkey name
+function create_monkey() {
+	MONKEY="$1"
+
+	echo "Configuring monkey with name $MONKEY"
+
+	${ECHO} mkdir -p "monkeys/$MONKEY/templates"
+	${ECHO} mkdir -p "monkeys/$MONKEY/.img"
+	${ECHO} cp templates/{*.sh,Chart.yaml} "monkeys/$MONKEY/"
+	${ECHO} cp templates/README-template.md "monkeys/$MONKEY/README.md"
+	if [ "$BARREL" -ne 0 ]; then
+		echo "Configuring as a barrel (statefulset) of monkeys..."
+		${ECHO} ln -sf "../../../templates/barrel-statefulset.yaml" -t "monkeys/${MONKEY}/templates/"
+		${ECHO} cp templates/values-barrel.yaml "monkeys/$MONKEY/values-$MONKEY.yaml"
+	else
+		echo "Configuring as monkey deployment..."
+		${ECHO} ln -sf "../../../templates/monkey-deployment.yaml" -t "monkeys/${MONKEY}/templates/"
+		${ECHO} cp templates/values-monkey.yaml "monkeys/$MONKEY/values-$MONKEY.yaml"
+	fi
+
+	monkey_files=$(find "monkeys/$MONKEY/" -type f)
+	${ECHO} sed -i 's/{{MONKEY_NAME}}/'"$MONKEY"'/g' $monkey_files
+
+	if [ "$POLICY" -ne 0 ]; then
+		echo "Configuring with policy to allow access to slack hook..."
+		${ECHO} ln -sf "../../../templates/slack-hook-policy.yaml" -t "monkeys/${MONKEY}/templates/"
+	fi
+
+	echo
+	echo "To set up the new monkey:"
+	echo " * Create any custom services or policies under monkeys/$MONKEY/templates/"
+	echo " * An image for the monkey must be placed into monkeys/$MONKEY/.img/$MONKEY.jpg"
+	echo " * Custom options may be set in the \"env\" section of monkeys/$MONKEY/values-$MONKEY.yaml"
+	echo " * Any shell scripts (*.sh) under monkeys/$MONKEY will be mounted within the pod under test/"
+	echo " * The following TODOs must be addressed:"
+	echo
+	grep TODO $monkey_files
+	echo
+	echo "After addressing the above tasks, use \"make\" to create the new" \
+	     "monkey YAMLs under deployments/."
+}
+
+function main() {
+	while [ $# -gt 0 ]; do
+	opt="$1"
+	case "$opt" in
+		-p|--policy)
+			POLICY=1
+			shift;;
+		-b|--barrel)
+			BARREL=1
+			shift;;
+		-h|--help)
+			usage
+			shift;
+			exit 0;;
+		*)
+			break;;
+	esac
+	done
+
+	if [ $# -lt 1 ]; then
+		usage
+		exit 1
+	fi
+
+	create_monkey "$1"
+}
+
+main "$@"

--- a/templates/Chart.yaml
+++ b/templates/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description:
+name: {{MONKEY_NAME}}
+version: 0.1.0

--- a/templates/README-template.md
+++ b/templates/README-template.md
@@ -1,0 +1,12 @@
+# Chaos Test: {{MONKEY_NAME}}
+
+![](https://github.com/cilium/chaos-monkeys/raw/master/monkeys/{{MONKEY_NAME}}/.img/{{MONKEY_NAME}}.jpg)
+
+## Test Description
+
+**TODO**: Fill out the description of this test.
+
+## Configuration
+
+* `SLEEP`: Sleep interval between attempt to reach `URL`
+* **TODO**: Add any custom configuration options here

--- a/templates/run.sh
+++ b/templates/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+ERROR_MSG="TODO: Update the error message"
+
+. $(dirname ${BASH_SOURCE})/helpers.bash
+
+init_monkey
+
+[ -z "$SLEEP" ] && {
+	SLEEP="10"
+}
+
+endpoint_debug_enable
+
+while :
+do
+	start_monitor
+	start_tcpdump
+
+	# **TODO**: populate '$?' by running a legitimate command
+	test_fail
+	CODE=$?
+	echo "$CODE"
+
+	stop_monitor
+	stop_tcpdump
+
+	[ "$CODE" -ne "0" ] && {
+		notify_slack ":fire: *$ERROR_MSG* (exit code $CODE) :face_palm:"
+		test_fail
+		exit 1
+	}
+
+	sleep $SLEEP
+done

--- a/templates/values-barrel.yaml
+++ b/templates/values-barrel.yaml
@@ -1,0 +1,4 @@
+name: "{{MONKEY_NAME}}"
+replicas: 2
+env:
+    sleep: "1"

--- a/templates/values-monkey.yaml
+++ b/templates/values-monkey.yaml
@@ -1,0 +1,4 @@
+name: "{{MONKEY_NAME}}"
+replicas: 5
+env:
+    sleep: "1"


### PR DESCRIPTION
```
$ ./create-monkey --help
Usage: ./create-monkey [OPTION ...] <monkey-name>

Create a new monkey from templates.

A monkey may be created as a deployment of cloned monkeys (the default), or as a statefulset of two monkeys which operate together (--barrel).

Options:
  -b,--barrel   Create a barrel of monkeys (2)
  -p,--policy   Set up default policy for slack hook
```

```
$ ./create-monkey foo
Configuring monkey with name foo
Configuring as monkey deployment...

To set up the new monkey:
 * Create any custom services or policies under monkeys/foo/templates/
 * An image for the monkey must be placed into monkeys/foo/.img/foo.jpg
 * Custom options may be set in the "env" section of monkeys/foo/values-foo.yaml
 * Any shell scripts (*.sh) under monkeys/foo will be mounted within the pod under test/
 * The following TODOs must be addressed:

monkeys/foo/README.md:**TODO**: Fill out the description of this test.
monkeys/foo/README.md:* **TODO**: Add any custom configuration options here
monkeys/foo/run.sh:ERROR_MSG="TODO: Update the error message"
monkeys/foo/run.sh:     # **TODO**: populate '$?' by running a legitimate command

After addressing the above tasks, use "make" to create the new monkey YAMLs under deployments/.
```