### PR TITLE
add `kubectl` binary into base-image as well as helper to bootstrap it within a pod

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -5,4 +5,6 @@ RUN apt-get update \
 RUN curl -LO http://releases.cilium.io/v1.2.0/cilium-x86_64 && \
     chmod +x cilium-x86_64 && \
     mv cilium-x86_64 /usr/bin/cilium
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl && \
+    chmod +x kubectl && mv kubectl /usr/bin/kubectl
 CMD []

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -11,6 +11,19 @@ function init_monkey() {
 	}
 }
 
+# bootstrap_kubectl configures the kubectl binary located within the pod to 
+# run against the cluster of which the pod is a member. It will have access
+# to any resource which is allowed in `rbac.yaml` at the root of this
+# repository.
+function bootstrap_kubectl() {
+  # Note that POD_NAMESPACE environment variable is injected via template files
+  # in templates/ 
+  kubectl config set-cluster ${POD_NAMESPACE} --server=https://${KUBERNETES_PORT_443_TCP_ADDR} --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  kubectl config set-context ${POD_NAMESPACE} --cluster=${POD_NAMESPACE}
+  kubectl config set-credentials user --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+  kubectl config set-context ${POD_NAMESPACE} --user=user
+}
+
 function endpoint_debug_enable() {
 	cilium endpoint config $ENDPOINT_ID debug=true
 }


### PR DESCRIPTION
This will allow for chaos-monkey pods to use `kubectl` to interact with the Kubernetes API instead of using `curl`. 

Signed-off by: Ian Vernon <ian@cilium.io>