### PR TITLE
Revert "lib: wrap monitor command into a shell to get correct pid"

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -41,7 +41,7 @@ function start_monitor() {
 		return
 	}
 
-	bash -c "cilium monitor -v | ts '[%Y-%m-%d %H:%M:%.S]' > $MONITOR_TMP" &
+	cilium monitor -v | ts '[%Y-%m-%d %H:%M:%.S]' > $MONITOR_TMP&
 	MONITOR_PID=$!
 }
 


### PR DESCRIPTION
This reverts commit 4eb188129832008431682d93d103f203837218e2.

Wrapping this command in a bash shell leads to leaking monitor
processes. Revert back to the previous version which, even though it
doesn't kill the monitor directly, it at least terminates the monitor indirectly
by killing the PID which is receiving its stdout.