### PR TITLE
add apple-tree monkey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 deployments
-monkeys/*/kubernetes-resources
+monkeys/shuffler/kubernetes-resources

--- a/monkeys/apple-tree/Chart.yaml
+++ b/monkeys/apple-tree/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description:
+name: apple-tree-controller
+version: 0.1.0

--- a/monkeys/apple-tree/README.md
+++ b/monkeys/apple-tree/README.md
@@ -1,0 +1,14 @@
+# Chaos Test: Apple Tree
+
+## Test Description
+
+This monkey has two pods: a controller which adds and deletes CIDR policies
+which refer to the same CIDR, and another pod which the CIDR policy selects,
+which queries the CIDR allowed by the policy. The monkey will complain via Slack
+if it cannot connect to the external CIDR.
+
+## Configuration
+
+* `MAXTIMEOUT`: if the entire request takes longer than this amount of time (in seconds), will be considered a failure. 
+* `CONNECTTIMEOUT`: if a request takes longer than this amount of time (in seconds) to connect, will be considered a failure.
+* `SLEEP`: time to sleep after both calls to Kubernetes and URL have completed.

--- a/monkeys/apple-tree/curl-format.txt
+++ b/monkeys/apple-tree/curl-format.txt
@@ -1,0 +1,10 @@
+\n
+            time_namelookup:  %{time_namelookup}(%{remote_ip})\n
+               time_connect:  %{time_connect}\n
+            time_appconnect:  %{time_appconnect}\n
+           time_pretransfer:  %{time_pretransfer}\n
+              time_redirect:  %{time_redirect}\n
+         time_starttransfer:  %{time_starttransfer}\n
+                            ----------\n
+                 time_total:  %{time_total}\n
+\n

--- a/monkeys/apple-tree/kubernetes-resources-charts/Chart.yaml
+++ b/monkeys/apple-tree/kubernetes-resources-charts/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description:
+name: apple-tree
+version: 0.1.0

--- a/monkeys/apple-tree/kubernetes-resources-charts/templates/client.yaml
+++ b/monkeys/apple-tree/kubernetes-resources-charts/templates/client.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.name }}-client
+spec:
+  replicas: {{ .Values.replicasclient }}
+  serviceName: {{ .Values.name }}-client
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}-client
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}-client
+    spec:
+      containers:
+      - name: {{ .Values.basename }}
+        image: docker.io/cilium/chaos-test-base:1.3
+        imagePullPolicy: IfNotPresent
+        command: [ "/test/run.sh" ]
+        env:
+          - name: "POD_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "SLACK_HOOK"
+            valueFrom:
+              configMapKeyRef:
+                name: monkey-config
+                key: slack-hook
+        {{- range $key, $value := .Values.env }}
+          - name: {{ $key | upper | replace "." "_" }}
+            value: {{ $value | quote }}
+        {{- end }}
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: run-script
+          mountPath: /test
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        securityContext:
+          capabilities:
+            add:
+              - "NET_ADMIN"
+          privileged: true
+      volumes:
+      - name: run-script
+        configMap:
+          name: chaos-test-{{ .Values.basename }}-script
+          defaultMode: 0777
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium

--- a/monkeys/apple-tree/kubernetes-resources-charts/values-apple-tree.yaml
+++ b/monkeys/apple-tree/kubernetes-resources-charts/values-apple-tree.yaml
@@ -1,0 +1,3 @@
+name: "apple-tree"
+env:
+  sleep: "1"

--- a/monkeys/apple-tree/kubernetes-resources/client.yaml
+++ b/monkeys/apple-tree/kubernetes-resources/client.yaml
@@ -1,0 +1,65 @@
+---
+# Source: apple-tree/templates/client.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: apple-tree-client
+spec:
+  replicas: 
+  serviceName: apple-tree-client
+  selector:
+    matchLabels:
+      name: apple-tree-client
+  template:
+    metadata:
+      labels:
+        name: apple-tree-client
+    spec:
+      containers:
+      - name: apple-tree
+        image: docker.io/cilium/chaos-test-base:1.3
+        imagePullPolicy: IfNotPresent
+        command: [ "/test/run.sh" ]
+        env:
+          - name: "POD_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "SLACK_HOOK"
+            valueFrom:
+              configMapKeyRef:
+                name: monkey-config
+                key: slack-hook
+          - name: SLEEP
+            value: "1"
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: run-script
+          mountPath: /test
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        securityContext:
+          capabilities:
+            add:
+              - "NET_ADMIN"
+          privileged: true
+      volumes:
+      - name: run-script
+        configMap:
+          name: chaos-test-apple-tree-script
+          defaultMode: 0777
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium
+

--- a/monkeys/apple-tree/kubernetes-resources/egress-cidr-policy-dup.yaml
+++ b/monkeys/apple-tree/kubernetes-resources/egress-cidr-policy-dup.yaml
@@ -1,0 +1,12 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "dup CIDR policy 2"
+metadata:
+  name: "duppoltwo"
+spec:
+  endpointSelector:
+    matchLabels:
+      name: apple-tree-client
+  egress:
+  - toCIDR:
+    - 1.1.1.1/32

--- a/monkeys/apple-tree/kubernetes-resources/egress-cidr-policy.yaml
+++ b/monkeys/apple-tree/kubernetes-resources/egress-cidr-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "dup CIDR policy 1"
+metadata:
+  name: "duppolone"
+spec:
+  endpointSelector:
+    matchLabels:
+      name: apple-tree-client
+  egress:
+  - toCIDR:
+    - 1.1.1.1/32

--- a/monkeys/apple-tree/run.sh
+++ b/monkeys/apple-tree/run.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -o pipefail
+
+
+. $(dirname ${BASH_SOURCE})/helpers.bash
+
+init_monkey
+
+
+API_TOKEN_PATH=${API_TOKEN_PATH:-/var/run/secrets/kubernetes.io/serviceaccount/token}
+KUBE_TOKEN=$(< ${API_TOKEN_PATH})
+KUBERNETES_PORT_443_TCP_ADDR=${KUBERNETES_PORT_443_TCP_ADDR:-kubernetes}
+EXTERNAL_CIDR="http://1.1.1.1"
+
+ERROR_MSG="oh noez! the apple fell far from the tree; (pod: $POD_NAME) failed"
+
+if [ ${DEBUG} ]; then
+  set -x
+fi
+
+[ -z "$MAXTIMEOUT" ] && {
+  MAXTIMEOUT="10"
+}
+
+[ -z "$CONNECTTIMEOUT" ] && {
+  CONNECTTIMEOUT=3
+}
+
+[ -z "$SLEEP" ] && {
+  SLEEP=10
+}
+
+
+endpoint_debug_enable
+
+function run_client() {
+  while :
+  do
+    start_monitor
+    start_tcpdump
+    log_line "trying to access ${EXTERNAL_CIDR}"
+    log_line "=========================================================="
+    CURLOUT=$(curl -s -D /dev/stderr --fail --connect-timeout $CONNECTTIMEOUT --max-time $MAXTIMEOUT "${EXTERNAL_CIDR}" -w "@/test/curl-format.txt")
+    CMDRES=$?
+    log_line "=========================================================="
+    if [[ "$CMDRES" != "0" ]]; then
+      notify_slack "*$ERROR_MSG* unable to connect to ${EXTERNAL_CIDR} : \`\`\`$CURLOUT\`\`\` (pod $HOSTNAME, exit code $CODE) :cry:"
+      test_fail
+      exit 1
+    fi
+
+
+    stop_monitor
+    stop_tcpdump
+
+    sleep $SLEEP
+  done
+}
+
+function cleanup_monkey() {
+  kubectl delete -f test/egress-cidr-policy.yaml 
+  kubectl delete -f test/egress-cidr-policy-dup.yaml
+}
+
+function add_delete_policies() {
+  while true ; do 
+    sleep 10
+    kubectl delete -f test/egress-cidr-policy-dup.yaml
+    sleep 10
+    kubectl apply -f test/egress-cidr-policy-dup.yaml
+    sleep 10
+    kubectl delete -f test/egress-cidr-policy.yaml
+    sleep 10
+    kubectl apply -f test/egress-cidr-policy.yaml
+  done
+}
+
+function run_controller() {
+  # First, import both policies
+  kubectl apply -f test/egress-cidr-policy.yaml
+  kubectl apply -f test/egress-cidr-policy-dup.yaml
+  kubectl apply -f test/client.yaml
+  # Let client get ready.
+  sleep 10
+  add_delete_policies
+}
+
+if [[ "$POD_NAME" =~ apple-tree-controller-* ]]; then
+  # Make sure we clean up the mess the monkeys make :) 
+  trap cleanup_monkey SIGTERM SIGINT EXIT
+  run_controller
+else
+  run_client
+fi
+

--- a/monkeys/apple-tree/templates/barrel-statefulset.yaml
+++ b/monkeys/apple-tree/templates/barrel-statefulset.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.name }}
+spec:
+  replicas: {{ .Values.replicas }}
+  serviceName: {{ .Values.name }}
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+    spec:
+      containers:
+      - name: {{ .Values.basename }}
+        image: docker.io/cilium/chaos-test-base:1.3
+        imagePullPolicy: Always
+        command: [ "/test/run.sh" ]
+        env:
+          - name: "POD_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "SLACK_HOOK"
+            valueFrom:
+              configMapKeyRef:
+                name: monkey-config
+                key: slack-hook
+        {{- range $key, $value := .Values.env }}
+          - name: {{ $key | upper | replace "." "_" }}
+            value: {{ $value | quote }}
+        {{- end }}
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: run-script
+          mountPath: /test
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        securityContext:
+          capabilities:
+            add:
+              - "NET_ADMIN"
+          privileged: true
+      volumes:
+      - name: run-script
+        configMap:
+          name: chaos-test-{{ .Values.basename }}-script
+          defaultMode: 0777
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium

--- a/monkeys/apple-tree/values-apple-tree.yaml
+++ b/monkeys/apple-tree/values-apple-tree.yaml
@@ -1,0 +1,5 @@
+name: "apple-tree-controller"
+env:
+  maxtimeout: "10"
+  connecttimeout: "3"
+  sleep: "10"

--- a/rbac.yaml
+++ b/rbac.yaml
@@ -53,3 +53,20 @@ rules:
       - create
       - patch
       - delete    
+  - apiGroups:
+    - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - "*"
+


### PR DESCRIPTION
This monkey likes CIDR's (get it? cider... it comes from apples).

This monkey has two pods: a controller which adds and deletes CIDR policies
which refer to the same CIDR, and another pod which the CIDR policy selects,
which queries the CIDR allowed by the policy. The monkey will complain via Slack
if it cannot connect to the external CIDR.
    
Signed-off by: Ian Vernon <ian@cilium.io>