### PR TITLE
et-call-home-fqdn-policy: Begin using DNS proxy

### DIFF
--- a/monkeys/et-call-home-fqdn-policy/run.sh
+++ b/monkeys/et-call-home-fqdn-policy/run.sh
@@ -22,7 +22,7 @@ do
 
 	echo -n "Trying to call home ($URL): "
 
-	time curl -4 -s $CURL_OPTIONS 10 $URL > /dev/null
+	time curl -4 -s $CURL_OPTIONS $URL > /dev/null
 	CODE=$?
 	echo "$CODE"
 

--- a/monkeys/et-call-home-fqdn-policy/run.sh
+++ b/monkeys/et-call-home-fqdn-policy/run.sh
@@ -20,9 +20,11 @@ do
 	start_monitor
 	start_tcpdump
 
-	echo -n "Trying to call home ($URL): "
+	echo -n "Trying to call 1.1.1.1: "
+	time curl -vvv -I  -w "dns: %{time_namelookup} connect: %{time_connect} total: %{time_total}\n" -4 -s $CURL_OPTIONS -o /dev/null 1.1.1.1 
 
-	time curl -4 -s $CURL_OPTIONS $URL > /dev/null
+	echo -n "Trying to call home ($URL): "
+	time curl -vvv -I -w "dns: %{time_namelookup} connect: %{time_connect} total: %{time_total}\n" -4 -s $CURL_OPTIONS -o /dev/null $URL
 	CODE=$?
 	echo "$CODE"
 

--- a/monkeys/et-call-home-fqdn-policy/templates/fqdn-policy.yaml
+++ b/monkeys/et-call-home-fqdn-policy/templates/fqdn-policy.yaml
@@ -14,10 +14,11 @@ spec:
     toPorts:
     - ports:
       - port: '53'
-        protocol: UDP
+        protocol: ANY
       rules:
         dns:
-          - matchPattern: "*.*"
-          - matchPattern: "*.*.*"
+          - matchName: {{ .Values.fqdn }}
   - toFQDNs:
       - matchName: {{ .Values.fqdn }}
+  - toCIDR:
+    - "1.1.1.1/32"

--- a/monkeys/et-call-home-fqdn-policy/templates/fqdn-policy.yaml
+++ b/monkeys/et-call-home-fqdn-policy/templates/fqdn-policy.yaml
@@ -15,5 +15,9 @@ spec:
     - ports:
       - port: '53'
         protocol: UDP
+      rules:
+        dns:
+          - matchPattern: "*.*"
+          - matchPattern: "*.*.*"
   - toFQDNs:
       - matchName: {{ .Values.fqdn }}

--- a/templates/slack-hook-policy.yaml
+++ b/templates/slack-hook-policy.yaml
@@ -15,5 +15,8 @@ spec:
     - ports:
       - port: '53'
         protocol: UDP
+      rules:
+        dns:
+        - matchName: "hooks.slack.com"
   - toFQDNs:
     - matchName: "hooks.slack.com"


### PR DESCRIPTION
cilium provides a DNS proxy, and has disabled the DNS poller. Switch the
et-call-home-fqdn-policy monkey's policy to use the new proxy.
