### PR TITLE
FQDN policy with S3 files.

### DIFF
--- a/monkeys/fqdn-s3/Chart.yaml
+++ b/monkeys/fqdn-s3/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description:
+name: fqdn-s3
+version: 0.1.0

--- a/monkeys/fqdn-s3/README.md
+++ b/monkeys/fqdn-s3/README.md
@@ -1,0 +1,21 @@
+# Chaos Test: fqdn-s3
+
+![](https://github.com/cilium/chaos-monkeys/raw/master/monkeys/fqdn-s3/.img/fqdn-s3.jpg)
+
+## Test Description
+
+This test make a HTTP HEAD call to a S3 file with a FQDN policy.
+
+The reason for this test is to verify that a new IP is added to the allowed list
+quickly enough to allow a HTTP connection.
+
+## Configuration
+
+* `SLEEP`: Sleep interval between attempt to reach `URL`
+* `CONNECTTIMEOUT`: The time that a connection will be drop. Default 5
+* `TARGETURL`: The target url to validate that the DNS works correctly.
+
+## Notes:
+
+* This monkey should create a lot of new identities, for cleanup in a faster
+  way, `--tofqdns-min-ttl` can be used to force lower expire time.

--- a/monkeys/fqdn-s3/run.sh
+++ b/monkeys/fqdn-s3/run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+ERROR_MSG="TODO: Update the error message"
+
+. $(dirname ${BASH_SOURCE})/helpers.bash
+
+init_monkey
+
+[ -z "$SLEEP" ] && {
+    SLEEP="10"
+}
+
+[ -z "$CONNECTTIMEOUT" ] && {
+    $CONNECTTIMEOUT="5"
+}
+endpoint_debug_enable
+
+while :
+do
+    start_monitor
+    start_tcpdump
+    curl --head --fail --connect-timeout "${CONNECTTIMEOUT}" "${TARGETURL}" \
+        -w "RemoteIP: %{remote_ip}\nDNSLOOKUP: %{time_namelookup}\nTotalTime: %{time_total}\nResponse: %{http_code}\n"
+    CODE=$?
+    stop_monitor
+    stop_tcpdump
+
+    [ "$CODE" -ne "0" ] && {
+        cilium identity list
+
+        notify_slack ":fire: *$ERROR_MSG* (pod $HOSTNAME, exit code $CODE) :face_palm:"
+        test_fail
+        exit 1
+    }
+
+    sleep $SLEEP
+done

--- a/monkeys/fqdn-s3/templates/monkey-deployment.yaml
+++ b/monkeys/fqdn-s3/templates/monkey-deployment.yaml
@@ -1,0 +1,1 @@
+../../../templates/monkey-deployment.yaml

--- a/monkeys/fqdn-s3/templates/policy.yaml
+++ b/monkeys/fqdn-s3/templates/policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: fqdn-s3-{{ .Values.basename }}
+spec:
+  endpointSelector:
+    matchLabels:
+      name: {{ .Values.name }}
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s-app: kube-dns
+    toPorts:
+    - ports:
+      - port: '53'
+        protocol: ANY
+      rules:
+        dns:
+          - matchName: {{ .Values.fqdn }}
+  - toFQDNs:
+      - matchName: {{ .Values.fqdn }}

--- a/monkeys/fqdn-s3/values-fqdn-s3.yaml
+++ b/monkeys/fqdn-s3/values-fqdn-s3.yaml
@@ -1,0 +1,7 @@
+name: "fqdn-s3"
+replicas: 3
+fqdn: "s3.amazonaws.com"
+env:
+    sleep: "5"
+    connectTimeout: "5"
+    targetURL: "https://s3.amazonaws.com/releases.cilium.io/tools/cluster-diagnosis.zip"


### PR DESCRIPTION
This is a new test that validates a FQDN policy with Amazon S3 URL that
updates the IPs frequently.

It will make a head request to the given target, if it replies with a
non 200 stauts code will fail. If in the given timeout cannot connect it
will fail.

For debugging porpouses the DNS lookup time will be printed also the
remoteIP,to make sure that is added in the identity list.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>