### PR TITLE
et-fqdn: Set 30s operation timeout

### DIFF
--- a/monkeys/et-call-home-fqdn-policy/values-call-google-fqdn-policy.yaml
+++ b/monkeys/et-call-home-fqdn-policy/values-call-google-fqdn-policy.yaml
@@ -4,4 +4,4 @@ fqdn: "www.google.com"
 env:
     url: "www.google.com"
     sleep: "3"
-    curl_options: "--connect-timeout 15 -S"
+    curl_options: "--connect-timeout 30 --max-time 30 -S"


### PR DESCRIPTION
We've observed failures when IP plumbing is delayed and, since we know
the cause and the fix, it would be nice to keep this monkey running and
only report other errors, like failed lookups. The max-time value should
also control non-connection parts of the request.
