### PR TITLE
Add namespace to monkey configmap

### DIFF
--- a/monkey-config.yaml
+++ b/monkey-config.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: chaos-testing
   name: monkey-config
 data:
   # 1. Create a Slack webhook: https://api.slack.com/incoming-webhooks


### PR DESCRIPTION
If the configmap is created in different ns than pod, the slack hook will not be available.