### PR TITLE
Update chaos monkeys for recent Helm and kubectl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,10 @@ all:
 	$(foreach monkey,$(MONKEYS),\
 	mkdir -p deployments/$(monkey); \
 	mkdir -p monkeys/$(monkey)/kubernetes-resources; \
-	$(foreach file,$(foreach kubeDep, $(wildcard monkeys/$(monkey)/kubernetes-resources-charts/templates/*yaml),$(notdir $(kubeDep)) ),\
-		 helm template monkeys/$(monkey)/kubernetes-resources-charts -x templates/$(file) --set basename=$(monkey) -f monkeys/$(monkey)/kubernetes-resources-charts/values-$(monkey).yaml > monkeys/$(monkey)/kubernetes-resources/$(file) ; ) \
-	kubectl create --dry-run configmap chaos-test-$(monkey)-script \
+	if [ -d monkeys/$(monkey)/kubernetes-resources-charts ]; then \
+		 helm template monkeys/$(monkey)/kubernetes-resources-charts --set basename=$(monkey) -f monkeys/$(monkey)/kubernetes-resources-charts/values-$(monkey).yaml > monkeys/$(monkey)/kubernetes-resources/$(monkey)-extra.yaml; \
+	fi; \
+	kubectl create --dry-run=client configmap chaos-test-$(monkey)-script \
 		--from-file=lib/helpers.bash \
 		$(foreach script,$(wildcard monkeys/$(monkey)/*.sh),\
 			"--from-file=$(script)"\

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ deploy: rbac
 
 undeploy:
 	$(foreach monkey,$(MONKEYS),kubectl -n chaos-testing delete -f deployments/$(monkey);)
+	kubectl delete svc --all -n chaos-testing
 
 clean:
 	rm -rf deployments

--- a/templates/monkey-deployment.yaml
+++ b/templates/monkey-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.name }}
 spec:
   replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fix various issues when deploying the chaos monkeys using helm 3 and kubectl v1.9.